### PR TITLE
Fix release workflow to use correct Go version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
## Summary
- Configure `setup-go` to read Go version from `go.mod` instead of using runner default
- Fixes release workflow failure where Go 1.24.13 was used but go.mod requires Go 1.25.0+

## Test plan
- Merge and tag a new release to verify the workflow succeeds

Made with [Cursor](https://cursor.com)